### PR TITLE
Add ability to get offline clients in the function getClientByUid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts3-nodejs-library",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "TeamSpeak Server Query API",
   "main": "lib/index.js",
   "homepage": "https://github.com/Multivit4min/TS3-NodeJS-Library",

--- a/src/TeamSpeak.ts
+++ b/src/TeamSpeak.ts
@@ -1158,7 +1158,7 @@ export class TeamSpeak extends EventEmitter {
       .then(([client]) => client)
       if (!retClient) {
         const dbRes = await this.clientDbFind(TeamSpeakClient.getUid(client), true)
-        if (dbRes.length === 0) return Number(dbRes[0].cldbid); else return undefined
+        if(dbRes.length > 0) return Number(dbRes[0].cldbid); else return undefined
       } else return retClient
   }
 

--- a/src/TeamSpeak.ts
+++ b/src/TeamSpeak.ts
@@ -1153,9 +1153,13 @@ export class TeamSpeak extends EventEmitter {
    * Retrieves a Single Client by the given Client Unique Identifier
    * @param client the client unique identifier
    */
-  getClientByUid(client: TeamSpeakClient.ClientType): Promise<TeamSpeakClient|undefined> {
-    return this.clientList({ clientUniqueIdentifier: TeamSpeakClient.getUid(client) })
+  async getClientByUid(client: TeamSpeakClient.ClientType): Promise<TeamSpeakClient|number|undefined> {
+    const retClient = await this.clientList({ clientUniqueIdentifier: TeamSpeakClient.getUid(client) })
       .then(([client]) => client)
+      if (!retClient) {
+        const dbRes = await this.clientDbFind(TeamSpeakClient.getUid(client), true)
+        if (dbRes.length === 0) return Number(dbRes[0].cldbid); else return undefined
+      } else return retClient
   }
 
 


### PR DESCRIPTION
## Preface
This PR will not change the parameters of `getClientByUid` but will simply change the response.

### Explanation
If the requested client is online, the `TeamSpeakClient` will be returned. If the requested client is offline, it will then check if the client is stored in the `clientDb` via the `clientDbFind` function with the function `TeamSpeakClient.getUid(client)` as it's parameter. If the user is found in the `clientDb`, their `clientDbUid` will be returned in the form of a number. This PR also includes a version bump from `3.4.1` -> `3.4.2`

#### Code changes
`TeamSpeak.ts` | Lines `1152` -> `1163`


### Credits
This change was authored by `racc#0001`, I am simply uploading and requesting the PR.