### PR TITLE
Update raw.ts

### DIFF
--- a/src/transport/protocols/raw.ts
+++ b/src/transport/protocols/raw.ts
@@ -37,7 +37,6 @@ export class ProtocolRAW extends EventEmitter implements TeamSpeakQuery.QueryPro
    * Called after the Socket has been established
    */
   private handleConnect() {
-    this.socket.setTimeout(0)
     this.emit("connect")
   }
 


### PR DESCRIPTION
it rewrites the readyTimeout param and doesn't timeout when couldn't create connection when given queryport is in use by other program or it is teamspeak servers serverport